### PR TITLE
Add create custom user in ec2 creation through user data.

### DIFF
--- a/Challenge_2/modules/ec2/main.tf
+++ b/Challenge_2/modules/ec2/main.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "custom_instance" {
   vpc_security_group_ids = var.security_group_ids
   user_data              = <<EOF
   #!/bin/bash 
+  sudo useradd -m "${var.instance_username}"
   sudo amazon-linux-extras install nginx1 -y
   sudo echo "<h2>Hello World!</h2>" > /usr/share/nginx/html/index.html
   sudo systemctl start nginx.service


### PR DESCRIPTION
- Adding the ability to create a custom user within the ec2 being created in the module. 

- Passing 'custom_username' as an input variable for the ec2 module, which creates the user in the ec2 instance.